### PR TITLE
Test cases to reproduce issue #16

### DIFF
--- a/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyEntityJpaPersisterTest.java
+++ b/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyEntityJpaPersisterTest.java
@@ -1,0 +1,136 @@
+package org.statefulj.persistence.jpa.lazy;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.statefulj.fsm.Persister;
+import org.statefulj.fsm.StaleStateException;
+import org.statefulj.fsm.model.State;
+import org.statefulj.persistence.jpa.Order;
+import org.statefulj.persistence.jpa.embedded.EmbeddedOrder;
+import org.statefulj.persistence.jpa.model.StatefulEntity;
+import org.statefulj.persistence.jpa.utils.UnitTestUtils;
+
+import javax.annotation.Resource;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"/applicationContext-JPAPersisterTests.xml"})
+public class LazyEntityJpaPersisterTest {
+
+    @Resource
+    Persister<LazyOrder> lazyJpaPersister;
+
+    @Resource
+    LazyOrderRepository lazyOrderRepo;
+
+    @Resource
+    JpaTransactionManager transactionManager;
+
+    @Resource
+    State<LazyOrder> stateA;
+
+    @Resource
+    State<LazyOrder> stateB;
+
+    @Resource
+    State<LazyOrder> stateC;
+
+    @Test
+    public void testValidStateChange() throws StaleStateException, NoSuchFieldException, IllegalAccessException {
+        //Setup the database
+        UnitTestUtils.startTransaction(transactionManager);
+
+        LazyOrder order = new LazyOrder();
+        order = lazyOrderRepo.save(order);
+
+        LazyOrder parentOrder = new LazyOrder();
+        parentOrder.setOrder(order);
+        parentOrder = lazyOrderRepo.save(parentOrder);
+
+        State<LazyOrder> currentState = lazyJpaPersister.getCurrent(order);
+        assertEquals(stateA, currentState);
+
+        long parentOrderId = parentOrder.getId();
+
+        UnitTestUtils.commitTransaction(transactionManager);
+
+        //Update state in transaction and verify
+        UnitTestUtils.startTransaction(transactionManager);
+
+        LazyOrder savedParentOrder = lazyOrderRepo.findOne(parentOrderId);
+        LazyOrder lazyChildOrder = savedParentOrder.getOrder();
+
+        assertEquals(stateA, lazyJpaPersister.getCurrent(lazyChildOrder));
+
+        lazyJpaPersister.setCurrent(lazyChildOrder, stateA, stateB);
+        assertEquals(stateB, lazyJpaPersister.getCurrent(lazyChildOrder));
+
+        UnitTestUtils.commitTransaction(transactionManager);
+
+        //Reload in another transaction, verify, and change to next state
+        UnitTestUtils.startTransaction(transactionManager);
+
+        savedParentOrder = lazyOrderRepo.findOne(parentOrderId);
+        lazyChildOrder = savedParentOrder.getOrder();
+        assertEquals(stateB, lazyJpaPersister.getCurrent(lazyChildOrder));
+        lazyJpaPersister.setCurrent(lazyChildOrder, stateB, stateC);
+
+        UnitTestUtils.commitTransaction(transactionManager);
+
+        //Reload in yet another transaction, verify and try to modify state directly
+        UnitTestUtils.startTransaction(transactionManager);
+
+        savedParentOrder = lazyOrderRepo.findOne(parentOrderId);
+        lazyChildOrder = savedParentOrder.getOrder();
+        assertEquals(stateC, lazyJpaPersister.getCurrent(lazyChildOrder));
+
+        Field stateField = StatefulEntity.class.getDeclaredField("state");
+        stateField.setAccessible(true);
+        stateField.set(lazyChildOrder, "stateD");
+
+        UnitTestUtils.commitTransaction(transactionManager);
+
+        //Verify that direct modification of the field does not updates state
+        UnitTestUtils.startTransaction(transactionManager);
+
+        savedParentOrder = lazyOrderRepo.findOne(parentOrderId);
+        lazyChildOrder = savedParentOrder.getOrder();
+        assertEquals(stateC, lazyJpaPersister.getCurrent(lazyChildOrder));
+
+        UnitTestUtils.commitTransaction(transactionManager);
+    }
+
+    @Test(expected=StaleStateException.class)
+    public void testInvalidStateChange() throws StaleStateException {
+        //Setup the database
+        UnitTestUtils.startTransaction(transactionManager);
+
+        LazyOrder order = new LazyOrder();
+        order = lazyOrderRepo.save(order);
+
+        LazyOrder parentOrder = new LazyOrder();
+        parentOrder.setOrder(order);
+        parentOrder = lazyOrderRepo.save(parentOrder);
+
+        assertEquals(stateA, lazyJpaPersister.getCurrent(order));
+
+        long parentOrderId = parentOrder.getId();
+
+        UnitTestUtils.commitTransaction(transactionManager);
+        UnitTestUtils.startTransaction(transactionManager);
+
+        LazyOrder savedParentOrder = lazyOrderRepo.findOne(parentOrderId);
+        LazyOrder lazyChildOrder = savedParentOrder.getOrder();
+
+        assertEquals(stateA, lazyJpaPersister.getCurrent(lazyChildOrder));
+
+        lazyJpaPersister.setCurrent(order, stateB, stateC);
+        UnitTestUtils.commitTransaction(transactionManager);
+    }
+}

--- a/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyEntityJpaPersisterTest.java
+++ b/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyEntityJpaPersisterTest.java
@@ -8,13 +8,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.statefulj.fsm.Persister;
 import org.statefulj.fsm.StaleStateException;
 import org.statefulj.fsm.model.State;
-import org.statefulj.persistence.jpa.Order;
-import org.statefulj.persistence.jpa.embedded.EmbeddedOrder;
 import org.statefulj.persistence.jpa.model.StatefulEntity;
 import org.statefulj.persistence.jpa.utils.UnitTestUtils;
 
 import javax.annotation.Resource;
-
 import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertEquals;
@@ -53,8 +50,7 @@ public class LazyEntityJpaPersisterTest {
         parentOrder.setOrder(order);
         parentOrder = lazyOrderRepo.save(parentOrder);
 
-        State<LazyOrder> currentState = lazyJpaPersister.getCurrent(order);
-        assertEquals(stateA, currentState);
+        assertEquals(stateA, lazyJpaPersister.getCurrent(order));
 
         long parentOrderId = parentOrder.getId();
 
@@ -130,7 +126,7 @@ public class LazyEntityJpaPersisterTest {
 
         assertEquals(stateA, lazyJpaPersister.getCurrent(lazyChildOrder));
 
-        lazyJpaPersister.setCurrent(order, stateB, stateC);
+        lazyJpaPersister.setCurrent(lazyChildOrder, stateB, stateC);
         UnitTestUtils.commitTransaction(transactionManager);
     }
 }

--- a/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyOrder.java
+++ b/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyOrder.java
@@ -1,0 +1,35 @@
+package org.statefulj.persistence.jpa.lazy;
+
+import org.statefulj.persistence.jpa.model.StatefulEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "LazyOrders")
+public class LazyOrder extends StatefulEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(unique = true, nullable = false)
+    private long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+    private LazyOrder order;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public LazyOrder getOrder() {
+        return order;
+    }
+
+    public void setOrder(LazyOrder order) {
+        this.order = order;
+    }
+}

--- a/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyOrderRepository.java
+++ b/statefulj-persistence/statefulj-persistence-jpa/src/test/java/org/statefulj/persistence/jpa/lazy/LazyOrderRepository.java
@@ -1,0 +1,10 @@
+package org.statefulj.persistence.jpa.lazy;
+
+import org.springframework.data.repository.Repository;
+
+public interface LazyOrderRepository extends Repository<LazyOrder, Long> {
+
+    LazyOrder save(LazyOrder order);
+
+    LazyOrder findOne(Long id);
+}

--- a/statefulj-persistence/statefulj-persistence-jpa/src/test/resources/applicationContext-JPAPersisterTests.xml
+++ b/statefulj-persistence/statefulj-persistence-jpa/src/test/resources/applicationContext-JPAPersisterTests.xml
@@ -50,4 +50,18 @@
     	<constructor-arg name="transactionManager" ref="transactionManager"/>
     </bean>
 
+	<bean id="lazyJpaPersister" class="org.statefulj.persistence.jpa.JPAPerister">
+		<constructor-arg name="clazz" value="org.statefulj.persistence.jpa.lazy.LazyOrder"/>
+		<constructor-arg name="startState" ref="stateA"/>
+		<constructor-arg name="states">
+			<util:list>
+				<ref bean="stateA"/>
+				<ref bean="stateB"/>
+				<ref bean="stateC"/>
+			</util:list>
+		</constructor-arg>
+		<constructor-arg name="entityManagerFactory" ref="entityManagerFactory"/>
+		<constructor-arg name="transactionManager" ref="transactionManager"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
Looks like main issues are
- Reading entity `@Id` and `@State` fields instead of accessing through getters;
- Updating state in a field, rather than setting it through a setter.
- Checking if entity is contained in some random `EntityManager` that is not aware of an ongoing transaction.

I'm working on a fix, but I've run into some issues with transaction management.