### PR TITLE
Fix for issue#26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<slf4j.version>1.7.7</slf4j.version>
 		<mockito.version>1.9.5</mockito.version>
 		<logback.version>1.0.13</logback.version>
-		<jdk.version>1.6</jdk.version>
+		<jdk.version>1.8</jdk.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/statefulj-framework/statefulj-framework-core/src/main/java/org/statefulj/framework/core/StatefulFactory.java
+++ b/statefulj-framework/statefulj-framework-core/src/main/java/org/statefulj/framework/core/StatefulFactory.java
@@ -380,7 +380,7 @@ public class StatefulFactory implements BeanDefinitionRegistryPostProcessor, App
 
 		// Determine the Entity Class associated with the Repo
 		//
-		String value = (String)bf.getPropertyValues().getPropertyValue("repositoryInterface").getValue();
+		String value = (String)bf.getAttribute("factoryBeanObjectType");
 		Class<?> repoInterface = Class.forName(value);
 		Class<?> entityType = null;
 		for(Type type : repoInterface.getGenericInterfaces()) {


### PR DESCRIPTION
This pull request has 2 parts:
1) Fix for issue#26. With the newer versions of spring-data-jpa, property "repositoryInterface" (in BeanDefinition) is not available. 
2) Workaround for issue#23 to work in JDK 1.8. For JDK < 1.8 fix, you might want to use the other pull request (https://github.com/statefulj/statefulj/pull/25)